### PR TITLE
rename Helm chart to 'adze' for environment-agnostic reuse

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -66,12 +66,12 @@ jobs:
       - name: Wait for pod to become ready
         run: |
           echo "⏳ Waiting for pod to be created..."
-          until oc get pods -n ${{ secrets.OPENSHIFT_NAMESPACE_DEV }} -l app.kubernetes.io/name=adze-dev -o name | grep pod; do
+          until oc get pods -n ${{ secrets.OPENSHIFT_NAMESPACE_DEV }} -l app.kubernetes.io/name=adze -o name | grep pod; do
             sleep 3
           done
       
           echo "⏳ Waiting for pod to become ready..."
-          until oc get pods -n ${{ secrets.OPENSHIFT_NAMESPACE_DEV }} -l app.kubernetes.io/name=adze-dev \
+          until oc get pods -n ${{ secrets.OPENSHIFT_NAMESPACE_DEV }} -l app.kubernetes.io/name=adze \
             -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null | grep true; do
             sleep 5
           done

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -46,12 +46,12 @@ jobs:
       - name: Wait for pod to become ready
         run: |
           echo "⏳ Waiting for pod to be created..."
-          until oc get pods -n c79ac4-test -l app.kubernetes.io/name=adze-test -o name | grep pod; do
+          until oc get pods -n c79ac4-test -l app.kubernetes.io/name=adze -o name | grep pod; do
             sleep 3
           done
       
           echo "⏳ Waiting for pod to become ready..."
-          until oc get pods -n c79ac4-test -l app.kubernetes.io/name=adze-test \
+          until oc get pods -n c79ac4-test -l app.kubernetes.io/name=adze \
             -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null | grep true; do
             sleep 5
           done

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: adze-dev
+name: adze
 description: A Helm chart for ADZE – XML to JSON Converter
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
## 🔹 Summary  
rename Helm chart to 'adze' for environment-agnostic reuse

## 🔹 Implementation Details  
- Updated Chart.yaml name from 'adze-dev' to 'adze'
- Ensures consistent chart identity across environments (dev, test, prod)
- Prevents route label issues and supports clean Helm upgrade/versioning